### PR TITLE
sign: only register supported signature schemes

### DIFF
--- a/sign/schemes/schemes.go
+++ b/sign/schemes/schemes.go
@@ -16,17 +16,21 @@ import (
 	"github.com/katzenpost/hpqc/sign/sphincsplus"
 )
 
-var allSchemes = [...]sign.Scheme{
+var potentialSchemes = [...]sign.Scheme{
+	// post quantum
+	sphincsplus.Scheme(),
+
+	// hybrid post quantum
+	hybrid.New("Ed25519 Sphincs+", ed25519.Scheme(), sphincsplus.Scheme()),
+	hybrid.New("Ed448-Sphincs+", ed448.Scheme(), sphincsplus.Scheme()),
+}
+
+var allSchemes = []sign.Scheme{
 	// classical
 	ed25519.Scheme(),
 	ed448.Scheme(),
 
-	// post quantum
-	sphincsplus.Scheme(),
-
-	// hybrid
-	hybrid.New("Ed25519 Sphincs+", ed25519.Scheme(), sphincsplus.Scheme()),
-	hybrid.New("Ed448-Sphincs+", ed448.Scheme(), sphincsplus.Scheme()),
+	// hybrid post quantum
 	eddilithium2.Scheme(),
 	eddilithium3.Scheme(),
 }
@@ -35,6 +39,12 @@ var allSchemeNames map[string]sign.Scheme
 
 func init() {
 	allSchemeNames = make(map[string]sign.Scheme)
+
+	for _, scheme := range potentialSchemes {
+		if scheme != nil {
+			allSchemes = append(allSchemes, scheme)
+		}
+	}
 	for _, scheme := range allSchemes {
 		allSchemeNames[strings.ToLower(scheme.Name())] = scheme
 	}
@@ -46,7 +56,7 @@ func ByName(name string) sign.Scheme {
 	return ret
 }
 
-// All returns all NIKE schemes supported.
+// All returns all signature schemes supported.
 func All() []sign.Scheme {
 	a := allSchemes
 	return a[:]

--- a/sign/sphincsplus/sphincs.go
+++ b/sign/sphincsplus/sphincs.go
@@ -1,3 +1,7 @@
+//go:build (darwin || linux) && amd64
+// +build darwin linux
+// +build amd64
+
 // SPDX-FileCopyrightText: (c) 2022-2024 David Stainton
 // SPDX-License-Identifier: AGPL-3.0-only
 

--- a/sign/sphincsplus/sphincs_not_supported.go
+++ b/sign/sphincsplus/sphincs_not_supported.go
@@ -1,0 +1,9 @@
+//go:build (!darwin || !linux) && !amd64
+
+package p
+
+import "github.com/katzenpost/hpqc/sign"
+
+func Scheme() sign.Scheme {
+	return nil
+}

--- a/sign/sphincsplus/sphincs_test.go
+++ b/sign/sphincsplus/sphincs_test.go
@@ -1,3 +1,7 @@
+//go:build (darwin || linux) && amd64
+// +build darwin linux
+// +build amd64
+
 // SPDX-FileCopyrightText: (c) 2022-2024 David Stainton
 // SPDX-License-Identifier: AGPL-3.0-only
 


### PR DESCRIPTION
Here we add build tags to sphincsplus so that it only builds on linux or darwin on amd64. anything else will get a sphincsplus Scheme() function that returns a nil scheme. the init() function inside our sign/schemes.go filters out potential schemes which are nil thus preventing them from getting registered by our sign/schemes API.