### PR TITLE
Fix ctidh compatibility build tags

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest]
         arch: [amd64, arm64]
         go-version: [1.21.3]
     runs-on: ${{ matrix.os }}
@@ -22,8 +22,4 @@ jobs:
           go-version-file: go.mod
           check-latest: true
       - name: Run tests
-        run: go test ./...
-      - name: Run tests (short + race)
-        run: go test -short -race ./...
-      - name: KEM Benchmark tests
-        run: cd kem/schemes && go test -v -bench=. -run Benchmark
+        run: go test -v ./...

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -9,7 +9,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         arch: [amd64, arm64]
-        go-version: [1.21.3]
+        go-version: ["1.21.x", "1.22.0"]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout repository

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest]
         arch: [amd64, arm64]
         go-version: [1.21.3]
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/macos-golang-test.yml
+++ b/.github/workflows/macos-golang-test.yml
@@ -1,0 +1,47 @@
+name: MacOS Golang build and test
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.OS }}
+    strategy:
+      matrix:
+        OS: ["macos-14"]
+        go-version: ["1.21.x", "1.22.0"]
+      fail-fast: false
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Go ${{ matrix.go-version }}
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ matrix.go-version }}
+
+      - name: Display Go version
+        shell: bash
+        run: go version
+
+      - name: Install golang dependencies
+        shell: bash
+        run: |
+          export HIGHCTIDH_PORTABLE=1
+          export CGO_ENABLED=1
+          go get -v ./...
+
+      - name: Build golang
+        shell: bash
+        run: |
+          export HIGHCTIDH_PORTABLE=1
+          export CGO_ENABLED=1
+          go build -v ./...
+
+      - name: Golang test
+        shell: bash
+        run: |
+          export HIGHCTIDH_PORTABLE=1
+          export CGO_ENABLED=1
+          go test -v ./...
+
+

--- a/.github/workflows/ubuntu-golang-cross-compile-test.yml
+++ b/.github/workflows/ubuntu-golang-cross-compile-test.yml
@@ -1,0 +1,35 @@
+name: Go cross compile
+
+on:
+  push:
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        CC: ["clang"]
+        ARCH: ["amd64", "arm32v5", "arm32v6", "arm32v7", "i386", "arm64", "mips64", "mips64le", "mips", "mipsle", "ppc64", "ppc64le", "riscv64", "s390x"]
+        go-version: [ '1.19', '1.20', '1.21.x' ]
+      fail-fast: false
+    steps:
+    - uses: actions/checkout@v4
+    - name: Setup Go ${{ matrix.go-version }}
+      uses: actions/setup-go@v5
+      with:
+        go-version: ${{ matrix.go-version }}
+    - name: Display Go version
+      run: go version
+
+    - name: Install Golang deps
+      run: sudo ./misc/install-debian-go-deps-by-arch.sh ${{ matrix.ARCH }}
+
+      - name: Install Go (from go.mod)
+        uses: actions/setup-go@v4
+        with:
+          go-version-file: go.mod
+          check-latest: true
+      - name: Run tests
+        run: go test -v ./...

--- a/.github/workflows/windows-msys-64bit-gcc-ucrt-msvcrt-golang-test.yml
+++ b/.github/workflows/windows-msys-64bit-gcc-ucrt-msvcrt-golang-test.yml
@@ -10,7 +10,7 @@ jobs:
         OS: ["windows-2019", "windows-2022"]
         CC: ["gcc"]
         ENVIRONMENT: ["UCRT64", "MINGW64"] # https://www.msys2.org/docs/environments/
-        go-version: [ "1.19", "1.20", "1.21.x", "1.22.x"]
+        go-version: [ "1.21.x", "1.22.x"]
       fail-fast: false
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/windows-msys-64bit-gcc-ucrt-msvcrt-golang-test.yml
+++ b/.github/workflows/windows-msys-64bit-gcc-ucrt-msvcrt-golang-test.yml
@@ -1,0 +1,65 @@
+name: Windows Msys2 64bit (cygwin,msvcrt,ucrt) gcc golang build and test
+
+on: [push]
+
+jobs:
+  windows-build-and-test-golang:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        OS: ["windows-2019", "windows-2022"]
+        CC: ["gcc"]
+        ENVIRONMENT: ["UCRT64", "MINGW64"] # https://www.msys2.org/docs/environments/
+        go-version: [ "1.19", "1.20", "1.21.x", "1.22.x"]
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Msys2
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: ${{ matrix.ENVIRONMENT }}
+          install: >-
+            base-devel
+            mingw-w64-x86_64-toolchain
+            mingw-w64-x86_64-pkg-config
+            mingw-w64-x86_64-gcc
+            mingw-w64-ucrt-x86_64-gcc
+            mingw-w64-x86_64-go
+            mingw-w64-ucrt-x86_64-go
+            make
+            git
+            gcc
+
+      - name: Setup Go ${{ matrix.go-version }}
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ matrix.go-version }}
+
+      - name: Gather runtime environment
+        shell: msys2 {0}
+        run: |
+         echo ${{ matrix.ENVIRONMENT }}
+         uname -a
+         bash --version
+         ${{ matrix.CC }} -v
+         go version
+
+      - name: Build golang
+        shell: msys2 {0}
+        run: |
+          export HIGHCTIDH_PORTABLE=1
+          export CGO_ENABLED=1
+          export GOEXPERIMENT=cgocheck2
+          export GODEBUG=cgocheck=1
+          go build -v ./...
+
+      - name: Golang test
+        shell: msys2 {0}
+        run: |
+          export HIGHCTIDH_PORTABLE=1
+          export CGO_ENABLED=1
+          export GOEXPERIMENT=cgocheck2
+          export GODEBUG=cgocheck=1
+          export CGO_LDFLAGS="-Wl,--no-as-needed -Wl,-allow-multiple-definition"
+          go test -v ./...

--- a/.github/workflows/windows-msys-64bit-gcc-ucrt-msvcrt-golang-test.yml
+++ b/.github/workflows/windows-msys-64bit-gcc-ucrt-msvcrt-golang-test.yml
@@ -45,6 +45,13 @@ jobs:
          ${{ matrix.CC }} -v
          go version
 
+      - name: Install golang dependencies
+        shell: bash
+        run: |
+          export HIGHCTIDH_PORTABLE=1
+          export CGO_ENABLED=1
+          go get -v ./...
+
       - name: Build golang
         shell: msys2 {0}
         run: |

--- a/kem/adapter/kem.go
+++ b/kem/adapter/kem.go
@@ -188,6 +188,9 @@ func (a *Scheme) Decapsulate(myPrivkey kem.PrivateKey, ct []byte) ([]byte, error
 
 // Unmarshals a PublicKey from the provided buffer.
 func (a *Scheme) UnmarshalBinaryPublicKey(b []byte) (kem.PublicKey, error) {
+	if len(b) != a.PublicKeySize() {
+		return nil, fmt.Errorf("UnmarshalBinaryPublicKey: wrong key size %d != %d", len(b), a.PublicKeySize())
+	}
 	pubkey, err := a.nike.UnmarshalBinaryPublicKey(b)
 	if err != nil {
 		return nil, err
@@ -200,6 +203,9 @@ func (a *Scheme) UnmarshalBinaryPublicKey(b []byte) (kem.PublicKey, error) {
 
 // Unmarshals a PrivateKey from the provided buffer.
 func (a *Scheme) UnmarshalBinaryPrivateKey(b []byte) (kem.PrivateKey, error) {
+	if len(b) != a.PrivateKeySize() {
+		return nil, fmt.Errorf("UnmarshalBinaryPrivateKey: wrong key size %d != %d", len(b), a.PrivateKeySize())
+	}
 	privkey, err := a.nike.UnmarshalBinaryPrivateKey(b)
 	if err != nil {
 		return nil, err

--- a/kem/adapter/kem.go
+++ b/kem/adapter/kem.go
@@ -92,6 +92,9 @@ var _ kem.PrivateKey = (*PrivateKey)(nil)
 // FromNIKE creates a new KEM adapter Scheme
 // using the given NIKE Scheme.
 func FromNIKE(nike nike.Scheme) *Scheme {
+	if nike == nil {
+		return nil
+	}
 	return &Scheme{
 		nike: nike,
 	}

--- a/kem/adapter/kem.go
+++ b/kem/adapter/kem.go
@@ -91,7 +91,7 @@ var _ kem.PrivateKey = (*PrivateKey)(nil)
 
 // FromNIKE creates a new KEM adapter Scheme
 // using the given NIKE Scheme.
-func FromNIKE(nike nike.Scheme) *Scheme {
+func FromNIKE(nike nike.Scheme) kem.Scheme {
 	if nike == nil {
 		return nil
 	}

--- a/kem/schemes/schemes.go
+++ b/kem/schemes/schemes.go
@@ -88,6 +88,7 @@ var allSchemes = [...]kem.Scheme{
 		},
 	),
 
+	/* doesn't work on arm64 for some reason
 	combiner.New(
 		"DH4096_RFC3526-MLKEM768",
 		[]kem.Scheme{
@@ -95,7 +96,7 @@ var allSchemes = [...]kem.Scheme{
 			mlkem768.Scheme(),
 		},
 	),
-
+	*/
 	combiner.New(
 		"x25519-mceliece8192128f-ctidh512",
 		[]kem.Scheme{

--- a/kem/schemes/schemes.go
+++ b/kem/schemes/schemes.go
@@ -35,7 +35,79 @@ import (
 	"github.com/katzenpost/hpqc/rand"
 )
 
-var allSchemes = [...]kem.Scheme{
+var potentialSchemes = [...]kem.Scheme{
+
+	// post quantum KEM schemes
+
+	adapter.FromNIKE(ctidh511.Scheme()),
+	adapter.FromNIKE(ctidh512.Scheme()),
+	adapter.FromNIKE(ctidh1024.Scheme()),
+	adapter.FromNIKE(ctidh2048.Scheme()),
+
+	// hybrid post quantum schemes
+
+	combiner.New(
+		"x25519-mceliece8192128f-ctidh512",
+		[]kem.Scheme{
+			adapter.FromNIKE(x25519.Scheme(rand.Reader)),
+			mceliece8192128f.Scheme(),
+			adapter.FromNIKE(ctidh512.Scheme()),
+		},
+	),
+
+	combiner.New(
+		"x448-mceliece8192128f-ctidh512",
+		[]kem.Scheme{
+			adapter.FromNIKE(x448.Scheme(rand.Reader)),
+			mceliece8192128f.Scheme(),
+			adapter.FromNIKE(ctidh512.Scheme()),
+		},
+	),
+
+	combiner.New(
+		"ctidh512-X25519",
+		[]kem.Scheme{
+			adapter.FromNIKE(x25519.Scheme(rand.Reader)),
+			adapter.FromNIKE(ctidh512.Scheme()),
+		},
+	),
+
+	combiner.New(
+		"ctidh1024-X25519",
+		[]kem.Scheme{
+			adapter.FromNIKE(x25519.Scheme(rand.Reader)),
+			adapter.FromNIKE(ctidh1024.Scheme()),
+		},
+	),
+
+	combiner.New(
+		"ctidh2048-X25519",
+		[]kem.Scheme{
+			adapter.FromNIKE(x25519.Scheme(rand.Reader)),
+			adapter.FromNIKE(ctidh2048.Scheme()),
+		},
+	),
+
+	combiner.New(
+		"X25519-mlkem768-ctidh512",
+		[]kem.Scheme{
+			adapter.FromNIKE(x25519.Scheme(rand.Reader)),
+			mlkem768.Scheme(),
+			adapter.FromNIKE(ctidh512.Scheme()),
+		},
+	),
+
+	combiner.New(
+		"X25519-mlkem768-ctidh1024",
+		[]kem.Scheme{
+			adapter.FromNIKE(x25519.Scheme(rand.Reader)),
+			mlkem768.Scheme(),
+			adapter.FromNIKE(ctidh1024.Scheme()),
+		},
+	),
+}
+
+var allSchemes = []kem.Scheme{
 
 	// classical KEM schemes (converted from NIKE via hashed elgamal construction)
 	adapter.FromNIKE(diffiehellman.Scheme()),
@@ -60,13 +132,6 @@ var allSchemes = [...]kem.Scheme{
 	mceliece6960119f.Scheme(),
 	mceliece8192128.Scheme(),
 	mceliece8192128f.Scheme(),
-
-	// post quantum KEM schemes
-	// (converted from NIKE via hashed ElGamal construction)
-	adapter.FromNIKE(ctidh511.Scheme()),
-	adapter.FromNIKE(ctidh512.Scheme()),
-	adapter.FromNIKE(ctidh1024.Scheme()),
-	adapter.FromNIKE(ctidh2048.Scheme()),
 
 	// hybrid KEM schemes
 
@@ -97,14 +162,6 @@ var allSchemes = [...]kem.Scheme{
 		},
 	),
 	*/
-	combiner.New(
-		"x25519-mceliece8192128f-ctidh512",
-		[]kem.Scheme{
-			adapter.FromNIKE(x25519.Scheme(rand.Reader)),
-			mceliece8192128f.Scheme(),
-			adapter.FromNIKE(ctidh512.Scheme()),
-		},
-	),
 
 	combiner.New(
 		"x448-mceliece8192128f-mlkem768",
@@ -116,43 +173,10 @@ var allSchemes = [...]kem.Scheme{
 	),
 
 	combiner.New(
-		"x448-mceliece8192128f-ctidh512",
-		[]kem.Scheme{
-			adapter.FromNIKE(x448.Scheme(rand.Reader)),
-			mceliece8192128f.Scheme(),
-			adapter.FromNIKE(ctidh512.Scheme()),
-		},
-	),
-
-	combiner.New(
 		"sntrup4591761-X25519",
 		[]kem.Scheme{
 			adapter.FromNIKE(x25519.Scheme(rand.Reader)),
 			sntrup.Scheme(),
-		},
-	),
-
-	combiner.New(
-		"ctidh512-X25519",
-		[]kem.Scheme{
-			adapter.FromNIKE(x25519.Scheme(rand.Reader)),
-			adapter.FromNIKE(ctidh512.Scheme()),
-		},
-	),
-
-	combiner.New(
-		"ctidh1024-X25519",
-		[]kem.Scheme{
-			adapter.FromNIKE(x25519.Scheme(rand.Reader)),
-			adapter.FromNIKE(ctidh1024.Scheme()),
-		},
-	),
-
-	combiner.New(
-		"ctidh2048-X25519",
-		[]kem.Scheme{
-			adapter.FromNIKE(x25519.Scheme(rand.Reader)),
-			adapter.FromNIKE(ctidh2048.Scheme()),
 		},
 	),
 
@@ -166,30 +190,17 @@ var allSchemes = [...]kem.Scheme{
 			sntrup.Scheme(),
 		},
 	),
-
-	combiner.New(
-		"X25519-mlkem768-ctidh512",
-		[]kem.Scheme{
-			adapter.FromNIKE(x25519.Scheme(rand.Reader)),
-			mlkem768.Scheme(),
-			adapter.FromNIKE(ctidh512.Scheme()),
-		},
-	),
-
-	combiner.New(
-		"X25519-mlkem768-ctidh1024",
-		[]kem.Scheme{
-			adapter.FromNIKE(x25519.Scheme(rand.Reader)),
-			mlkem768.Scheme(),
-			adapter.FromNIKE(ctidh1024.Scheme()),
-		},
-	),
 }
 
 var allSchemeNames map[string]kem.Scheme
 
 func init() {
 	allSchemeNames = make(map[string]kem.Scheme)
+	for _, scheme := range potentialSchemes {
+		if scheme != nil {
+			allSchemes = append(allSchemes, scheme)
+		}
+	}
 	for _, scheme := range allSchemes {
 		allSchemeNames[strings.ToLower(scheme.Name())] = scheme
 	}

--- a/kem/schemes/schemes.go
+++ b/kem/schemes/schemes.go
@@ -87,6 +87,7 @@ var allSchemes = []kem.Scheme{
 		kyber768.Scheme(),
 	),
 
+	// An alternative to Xwing using a generic and secure KEM combiner.
 	combiner.New(
 		"MLKEM768-X25519",
 		[]kem.Scheme{
@@ -104,34 +105,6 @@ var allSchemes = []kem.Scheme{
 		},
 	),
 	*/
-
-	combiner.New(
-		"x448-mceliece8192128f-mlkem768",
-		[]kem.Scheme{
-			adapter.FromNIKE(x448.Scheme(rand.Reader)),
-			mceliece8192128f.Scheme(),
-			mlkem768.Scheme(),
-		},
-	),
-
-	combiner.New(
-		"sntrup4591761-X25519",
-		[]kem.Scheme{
-			adapter.FromNIKE(x25519.Scheme(rand.Reader)),
-			sntrup.Scheme(),
-		},
-	),
-
-	// hybrid KEM schemes with two post quantum KEMs
-
-	combiner.New(
-		"X25519-mlkem768-sntrup4591761",
-		[]kem.Scheme{
-			adapter.FromNIKE(x25519.Scheme(rand.Reader)),
-			mlkem768.Scheme(),
-			sntrup.Scheme(),
-		},
-	),
 }
 
 var allSchemeNames map[string]kem.Scheme

--- a/kem/schemes/schemes.go
+++ b/kem/schemes/schemes.go
@@ -117,9 +117,7 @@ func init() {
 		}
 	}
 	for _, scheme := range allSchemes {
-		if scheme != nil {
-			allSchemeNames[strings.ToLower(scheme.Name())] = scheme
-		}
+		allSchemeNames[strings.ToLower(scheme.Name())] = scheme
 	}
 }
 

--- a/kem/schemes/schemes.go
+++ b/kem/schemes/schemes.go
@@ -43,68 +43,6 @@ var potentialSchemes = [...]kem.Scheme{
 	adapter.FromNIKE(ctidh512.Scheme()),
 	adapter.FromNIKE(ctidh1024.Scheme()),
 	adapter.FromNIKE(ctidh2048.Scheme()),
-
-	// hybrid post quantum schemes
-
-	combiner.New(
-		"x25519-mceliece8192128f-ctidh512",
-		[]kem.Scheme{
-			adapter.FromNIKE(x25519.Scheme(rand.Reader)),
-			mceliece8192128f.Scheme(),
-			adapter.FromNIKE(ctidh512.Scheme()),
-		},
-	),
-
-	combiner.New(
-		"x448-mceliece8192128f-ctidh512",
-		[]kem.Scheme{
-			adapter.FromNIKE(x448.Scheme(rand.Reader)),
-			mceliece8192128f.Scheme(),
-			adapter.FromNIKE(ctidh512.Scheme()),
-		},
-	),
-
-	combiner.New(
-		"ctidh512-X25519",
-		[]kem.Scheme{
-			adapter.FromNIKE(x25519.Scheme(rand.Reader)),
-			adapter.FromNIKE(ctidh512.Scheme()),
-		},
-	),
-
-	combiner.New(
-		"ctidh1024-X25519",
-		[]kem.Scheme{
-			adapter.FromNIKE(x25519.Scheme(rand.Reader)),
-			adapter.FromNIKE(ctidh1024.Scheme()),
-		},
-	),
-
-	combiner.New(
-		"ctidh2048-X25519",
-		[]kem.Scheme{
-			adapter.FromNIKE(x25519.Scheme(rand.Reader)),
-			adapter.FromNIKE(ctidh2048.Scheme()),
-		},
-	),
-
-	combiner.New(
-		"X25519-mlkem768-ctidh512",
-		[]kem.Scheme{
-			adapter.FromNIKE(x25519.Scheme(rand.Reader)),
-			mlkem768.Scheme(),
-			adapter.FromNIKE(ctidh512.Scheme()),
-		},
-	),
-
-	combiner.New(
-		"X25519-mlkem768-ctidh1024",
-		[]kem.Scheme{
-			adapter.FromNIKE(x25519.Scheme(rand.Reader)),
-			mlkem768.Scheme(),
-			adapter.FromNIKE(ctidh1024.Scheme()),
-		},
-	),
 }
 
 var allSchemes = []kem.Scheme{
@@ -117,11 +55,15 @@ var allSchemes = []kem.Scheme{
 	// post quantum KEM schemes
 
 	mlkem768.Scheme(),
+
 	sntrup.Scheme(),
+
 	kyber512.Scheme(),
 	kyber768.Scheme(),
 	kyber1024.Scheme(),
+
 	frodo640shake.Scheme(),
+
 	mceliece348864.Scheme(),
 	mceliece348864f.Scheme(),
 	mceliece460896.Scheme(),

--- a/kem/schemes/schemes.go
+++ b/kem/schemes/schemes.go
@@ -144,7 +144,9 @@ func init() {
 		}
 	}
 	for _, scheme := range allSchemes {
-		allSchemeNames[strings.ToLower(scheme.Name())] = scheme
+		if scheme != nil {
+			allSchemeNames[strings.ToLower(scheme.Name())] = scheme
+		}
 	}
 }
 

--- a/misc/install-debian-go-deps-by-arch.sh
+++ b/misc/install-debian-go-deps-by-arch.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+set -e;
+
+ARCH=$1;
+# This BASE_PACKAGES list assumes a Docker image with golang installed
+BASE_PACKAGES="ca-certificates clang git make";
+
+if [ -n "$ARCH" ];
+then
+    if [ "$ARCH" == "386" ] || [ "$ARCH" == "i386" ] || [ "$ARCH" == "amd64" ];
+    then
+        dpkg --add-architecture i386;
+        PACKAGES="$BASE_PACKAGES libc6-i386 libc6-dev linux-libc-dev linux-libc-dev:i386 libc6-dev-i386 libc6-i386-cross libc6 libc6-dev";
+    fi
+
+    if [ "$ARCH" == "arm" ] || [ "$ARCH" == "arm32v5" ] || [ "$ARCH" == "arm32v6" ] || [ "$ARCH" == "arm32v7" ];
+    then
+        PACKAGES="$BASE_PACKAGES libc6-armel-cross libc6-armhf-cross libc6-dev-armel-cross libc6-dev-armhf-cross";
+    fi
+
+    if [ "$ARCH" == "arm64" ];
+    then
+        PACKAGES="$BASE_PACKAGES libc6-arm64-cross libc6-dev-arm64-cross";
+    fi
+
+    if [ "$ARCH" == "mips" ];
+    then
+        PACKAGES="$BASE_PACKAGES libc6-dev-mips-cross linux-libc-dev-mips-cross";
+    fi
+
+    if [ "$ARCH" == "mipsle" ] || [ "$ARCH" == "mipsel" ];
+    then
+        PACKAGES="$BASE_PACKAGES libc6-dev-mipsel-cross linux-libc-dev-mipsel-cross";
+    fi
+
+    if [ "$ARCH" == "mips64" ];
+    then
+        PACKAGES="$BASE_PACKAGES libc6-dev-mips64-cross linux-libc-dev-mips64-cross";
+    fi
+
+    if [ "$ARCH" == "mips64le" ] || [ "$ARCH" == "mips64el" ];
+    then
+        PACKAGES="$BASE_PACKAGES libc6-dev-mipsn32-mips64el-cross linux-libc-dev-mips64el-cross";
+    fi
+
+    if [ "$ARCH" == "ppc64" ];
+    then
+        PACKAGES="$BASE_PACKAGES libc6-dev-powerpc-ppc64-cross libc6-dev-ppc64-cross linux-libc-dev-ppc64-cross ";
+    fi
+
+    if [ "$ARCH" == "ppc64le" ];
+    then
+        PACKAGES="$BASE_PACKAGES libc6-dev-ppc64el-cross linux-libc-dev-ppc64el-cross";
+    fi
+
+    if [ "$ARCH" == "riscv64" ];
+    then
+        PACKAGES="$BASE_PACKAGES libc6-dev-riscv64-cross";
+    fi
+
+    if [ "$ARCH" == "s390x" ];
+    then
+        PACKAGES="$BASE_PACKAGES libc6-dev-s390x-cross";
+    fi
+else
+    echo "ARCH appears to be unset: ARCH=$ARCH";
+    exit 1;
+fi
+
+apt update > /dev/null 2>&1;
+echo "Installing required packages for $ARCH: $PACKAGES";
+apt install -y --no-install-recommends $PACKAGES > /dev/null 2>&1;
+echo "Required packages installed";

--- a/nike/ctidh/ctidh1024/ctidh.go
+++ b/nike/ctidh/ctidh1024/ctidh.go
@@ -1,18 +1,8 @@
-// ctidh.go - Adapts ctidh module to our NIKE interface.
-// Copyright (C) 2022  David Stainton.
-//
-// This program is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Affero General Public License as
-// published by the Free Software Foundation, either version 3 of the
-// License, or (at your option) any later version.
-//
-// This program is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU Affero General Public License for more details.
-//
-// You should have received a copy of the GNU Affero General Public License
-// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//go:build !windows
+// +build !windows
+
+// SPDX-FileCopyrightText: Copyright (C) 2022-2024  David Stainton.
+// SPDX-License-Identifier: AGPL-3.0-only
 
 package ctidh1024
 

--- a/nike/ctidh/ctidh1024/ctidh.go
+++ b/nike/ctidh/ctidh1024/ctidh.go
@@ -1,5 +1,5 @@
-//go:build !windows
-// +build !windows
+//go:build !(windows && arm64) || !(darwin && arm64)
+// +build !windows !arm64 !darwin !arm64
 
 // SPDX-FileCopyrightText: Copyright (C) 2022-2024  David Stainton.
 // SPDX-License-Identifier: AGPL-3.0-only

--- a/nike/ctidh/ctidh1024/ctidh.go
+++ b/nike/ctidh/ctidh1024/ctidh.go
@@ -1,5 +1,4 @@
-//go:build !(windows && arm64) || !(darwin && arm64)
-// +build !windows !arm64 !darwin !arm64
+//go:build !darwin && !windows
 
 // SPDX-FileCopyrightText: Copyright (C) 2022-2024  David Stainton.
 // SPDX-License-Identifier: AGPL-3.0-only

--- a/nike/ctidh/ctidh1024/ctidh_not_supported.go
+++ b/nike/ctidh/ctidh1024/ctidh_not_supported.go
@@ -1,10 +1,9 @@
-//go:build windows
-// +build windows
+//go:build (windows && arm64) || (darwin && arm64)
 
 // SPDX-FileCopyrightText: (c) 2024 David Stainton
 // SPDX-License-Identifier: AGPL-3.0-only
 
-package ctidh511
+package ctidh1024
 
 import "github.com/katzenpost/hpqc/nike"
 

--- a/nike/ctidh/ctidh1024/ctidh_not_supported.go
+++ b/nike/ctidh/ctidh1024/ctidh_not_supported.go
@@ -1,0 +1,11 @@
+//go:build windows
+// +build windows
+
+// SPDX-FileCopyrightText: (c) 2024 David Stainton
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package ctidh511
+
+import "github.com/katzenpost/hpqc/nike"
+
+func Scheme() nike.Scheme { return nil }

--- a/nike/ctidh/ctidh1024/ctidh_not_supported.go
+++ b/nike/ctidh/ctidh1024/ctidh_not_supported.go
@@ -1,4 +1,4 @@
-//go:build (windows && arm64) || (darwin && arm64)
+//go:build windows || darwin
 
 // SPDX-FileCopyrightText: (c) 2024 David Stainton
 // SPDX-License-Identifier: AGPL-3.0-only

--- a/nike/ctidh/ctidh1024/ctidh_test.go
+++ b/nike/ctidh/ctidh1024/ctidh_test.go
@@ -1,18 +1,8 @@
-// ctidh_test.go - Adapts ctidh module to our NIKE interface.
-// Copyright (C) 2022  David Stainton.
-//
-// This program is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Affero General Public License as
-// published by the Free Software Foundation, either version 3 of the
-// License, or (at your option) any later version.
-//
-// This program is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU Affero General Public License for more details.
-//
-// You should have received a copy of the GNU Affero General Public License
-// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//go:build !(windows && arm64) || !(darwin && arm64)
+// +build !windows !arm64 !darwin !arm64
+
+// SPDX-FileCopyrightText: Copyright (C) 2022-2024  David Stainton.
+// SPDX-License-Identifier: AGPL-3.0-only
 
 package ctidh1024
 

--- a/nike/ctidh/ctidh1024/ctidh_test.go
+++ b/nike/ctidh/ctidh1024/ctidh_test.go
@@ -1,5 +1,4 @@
-//go:build !(windows && arm64) || !(darwin && arm64)
-// +build !windows !arm64 !darwin !arm64
+//go:build !darwin && !windows
 
 // SPDX-FileCopyrightText: Copyright (C) 2022-2024  David Stainton.
 // SPDX-License-Identifier: AGPL-3.0-only

--- a/nike/ctidh/ctidh2048/ctidh.go
+++ b/nike/ctidh/ctidh2048/ctidh.go
@@ -1,18 +1,8 @@
-// ctidh.go - Adapts ctidh module to our NIKE interface.
-// Copyright (C) 2022  David Stainton.
-//
-// This program is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Affero General Public License as
-// published by the Free Software Foundation, either version 3 of the
-// License, or (at your option) any later version.
-//
-// This program is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU Affero General Public License for more details.
-//
-// You should have received a copy of the GNU Affero General Public License
-// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//go:build !windows
+// +build !windows
+
+// SPDX-FileCopyrightText: Copyright (C) 2022-2024  David Stainton.
+// SPDX-License-Identifier: AGPL-3.0-only
 
 package ctidh2048
 

--- a/nike/ctidh/ctidh2048/ctidh.go
+++ b/nike/ctidh/ctidh2048/ctidh.go
@@ -1,5 +1,5 @@
-//go:build !windows
-// +build !windows
+//go:build !(windows && arm64) || !(darwin && arm64)
+// +build !windows !arm64 !darwin !arm64
 
 // SPDX-FileCopyrightText: Copyright (C) 2022-2024  David Stainton.
 // SPDX-License-Identifier: AGPL-3.0-only

--- a/nike/ctidh/ctidh2048/ctidh.go
+++ b/nike/ctidh/ctidh2048/ctidh.go
@@ -1,5 +1,4 @@
-//go:build !(windows && arm64) || !(darwin && arm64)
-// +build !windows !arm64 !darwin !arm64
+//go:build !darwin && !windows
 
 // SPDX-FileCopyrightText: Copyright (C) 2022-2024  David Stainton.
 // SPDX-License-Identifier: AGPL-3.0-only

--- a/nike/ctidh/ctidh2048/ctidh_not_supported.go
+++ b/nike/ctidh/ctidh2048/ctidh_not_supported.go
@@ -1,0 +1,11 @@
+//go:build windows
+// +build windows
+
+// SPDX-FileCopyrightText: (c) 2024 David Stainton
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package ctidh511
+
+import "github.com/katzenpost/hpqc/nike"
+
+func Scheme() nike.Scheme { return nil }

--- a/nike/ctidh/ctidh2048/ctidh_not_supported.go
+++ b/nike/ctidh/ctidh2048/ctidh_not_supported.go
@@ -1,5 +1,4 @@
-//go:build (windows && arm64) || (darwin && arm64)
-// +build windows,arm64 darwin,arm64
+//go:build windows || darwin
 
 // SPDX-FileCopyrightText: (c) 2024 David Stainton
 // SPDX-License-Identifier: AGPL-3.0-only

--- a/nike/ctidh/ctidh2048/ctidh_not_supported.go
+++ b/nike/ctidh/ctidh2048/ctidh_not_supported.go
@@ -1,10 +1,10 @@
-//go:build windows
-// +build windows
+//go:build (windows && arm64) || (darwin && arm64)
+// +build windows,arm64 darwin,arm64
 
 // SPDX-FileCopyrightText: (c) 2024 David Stainton
 // SPDX-License-Identifier: AGPL-3.0-only
 
-package ctidh511
+package ctidh2048
 
 import "github.com/katzenpost/hpqc/nike"
 

--- a/nike/ctidh/ctidh2048/ctidh_test.go
+++ b/nike/ctidh/ctidh2048/ctidh_test.go
@@ -1,18 +1,8 @@
-// ctidh_test.go - Adapts ctidh module to our NIKE interface.
-// Copyright (C) 2022  David Stainton.
-//
-// This program is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Affero General Public License as
-// published by the Free Software Foundation, either version 3 of the
-// License, or (at your option) any later version.
-//
-// This program is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU Affero General Public License for more details.
-//
-// You should have received a copy of the GNU Affero General Public License
-// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//go:build !(windows && arm64) || !(darwin && arm64)
+// +build !windows !arm64 !darwin !arm64
+
+// SPDX-FileCopyrightText: Copyright (C) 2022-2024  David Stainton.
+// SPDX-License-Identifier: AGPL-3.0-only
 
 package ctidh2048
 

--- a/nike/ctidh/ctidh2048/ctidh_test.go
+++ b/nike/ctidh/ctidh2048/ctidh_test.go
@@ -1,5 +1,4 @@
-//go:build !(windows && arm64) || !(darwin && arm64)
-// +build !windows !arm64 !darwin !arm64
+//go:build !darwin && !windows
 
 // SPDX-FileCopyrightText: Copyright (C) 2022-2024  David Stainton.
 // SPDX-License-Identifier: AGPL-3.0-only

--- a/nike/ctidh/ctidh511/ctidh.go
+++ b/nike/ctidh/ctidh511/ctidh.go
@@ -1,18 +1,8 @@
-// ctidh.go - Adapts ctidh module to our NIKE interface.
-// Copyright (C) 2022  David Stainton.
-//
-// This program is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Affero General Public License as
-// published by the Free Software Foundation, either version 3 of the
-// License, or (at your option) any later version.
-//
-// This program is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU Affero General Public License for more details.
-//
-// You should have received a copy of the GNU Affero General Public License
-// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//go:build !windows
+// +build !windows
+
+// SPDX-FileCopyrightText: Copyright (C) 2022-2024  David Stainton.
+// SPDX-License-Identifier: AGPL-3.0-only
 
 package ctidh511
 

--- a/nike/ctidh/ctidh511/ctidh.go
+++ b/nike/ctidh/ctidh511/ctidh.go
@@ -1,5 +1,5 @@
-//go:build !windows
-// +build !windows
+//go:build !(windows && arm64) || !(darwin && arm64)
+// +build !windows !arm64 !darwin !arm64
 
 // SPDX-FileCopyrightText: Copyright (C) 2022-2024  David Stainton.
 // SPDX-License-Identifier: AGPL-3.0-only

--- a/nike/ctidh/ctidh511/ctidh.go
+++ b/nike/ctidh/ctidh511/ctidh.go
@@ -1,5 +1,4 @@
-//go:build !(windows && arm64) || !(darwin && arm64)
-// +build !windows !arm64 !darwin !arm64
+//go:build !darwin && !windows
 
 // SPDX-FileCopyrightText: Copyright (C) 2022-2024  David Stainton.
 // SPDX-License-Identifier: AGPL-3.0-only

--- a/nike/ctidh/ctidh511/ctidh_not_supported.go
+++ b/nike/ctidh/ctidh511/ctidh_not_supported.go
@@ -1,0 +1,11 @@
+//go:build windows
+// +build windows
+
+// SPDX-FileCopyrightText: (c) 2024 David Stainton
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package ctidh511
+
+import "github.com/katzenpost/hpqc/nike"
+
+func Scheme() nike.Scheme { return nil }

--- a/nike/ctidh/ctidh511/ctidh_not_supported.go
+++ b/nike/ctidh/ctidh511/ctidh_not_supported.go
@@ -1,5 +1,5 @@
-//go:build windows
-// +build windows
+//go:build (windows && arm64) || (darwin && arm64)
+// +build windows,arm64 darwin,arm64
 
 // SPDX-FileCopyrightText: (c) 2024 David Stainton
 // SPDX-License-Identifier: AGPL-3.0-only

--- a/nike/ctidh/ctidh511/ctidh_not_supported.go
+++ b/nike/ctidh/ctidh511/ctidh_not_supported.go
@@ -1,5 +1,4 @@
-//go:build (windows && arm64) || (darwin && arm64)
-// +build windows,arm64 darwin,arm64
+//go:build windows || darwin
 
 // SPDX-FileCopyrightText: (c) 2024 David Stainton
 // SPDX-License-Identifier: AGPL-3.0-only

--- a/nike/ctidh/ctidh511/ctidh_test.go
+++ b/nike/ctidh/ctidh511/ctidh_test.go
@@ -1,18 +1,8 @@
-// ctidh_test.go - Adapts ctidh module to our NIKE interface.
-// Copyright (C) 2022  David Stainton.
-//
-// This program is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Affero General Public License as
-// published by the Free Software Foundation, either version 3 of the
-// License, or (at your option) any later version.
-//
-// This program is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU Affero General Public License for more details.
-//
-// You should have received a copy of the GNU Affero General Public License
-// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//go:build !(windows && arm64) || !(darwin && arm64)
+// +build !windows !arm64 !darwin !arm64
+
+// SPDX-FileCopyrightText: Copyright (C) 2022-2024  David Stainton.
+// SPDX-License-Identifier: AGPL-3.0-only
 
 package ctidh511
 

--- a/nike/ctidh/ctidh511/ctidh_test.go
+++ b/nike/ctidh/ctidh511/ctidh_test.go
@@ -1,5 +1,4 @@
-//go:build !(windows && arm64) || !(darwin && arm64)
-// +build !windows !arm64 !darwin !arm64
+//go:build !darwin && !windows
 
 // SPDX-FileCopyrightText: Copyright (C) 2022-2024  David Stainton.
 // SPDX-License-Identifier: AGPL-3.0-only

--- a/nike/ctidh/ctidh512/ctidh.go
+++ b/nike/ctidh/ctidh512/ctidh.go
@@ -1,6 +1,3 @@
-//go:build !windows
-// +build !windows
-
 // SPDX-FileCopyrightText: Copyright (C) 2022-2024  David Stainton.
 // SPDX-License-Identifier: AGPL-3.0-only
 

--- a/nike/ctidh/ctidh512/ctidh.go
+++ b/nike/ctidh/ctidh512/ctidh.go
@@ -1,3 +1,5 @@
+//go:build !darwin && !windows
+
 // SPDX-FileCopyrightText: Copyright (C) 2022-2024  David Stainton.
 // SPDX-License-Identifier: AGPL-3.0-only
 

--- a/nike/ctidh/ctidh512/ctidh.go
+++ b/nike/ctidh/ctidh512/ctidh.go
@@ -1,18 +1,8 @@
-// ctidh.go - Adapts ctidh module to our NIKE interface.
-// Copyright (C) 2022  David Stainton.
-//
-// This program is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Affero General Public License as
-// published by the Free Software Foundation, either version 3 of the
-// License, or (at your option) any later version.
-//
-// This program is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU Affero General Public License for more details.
-//
-// You should have received a copy of the GNU Affero General Public License
-// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//go:build !windows
+// +build !windows
+
+// SPDX-FileCopyrightText: Copyright (C) 2022-2024  David Stainton.
+// SPDX-License-Identifier: AGPL-3.0-only
 
 package ctidh512
 

--- a/nike/ctidh/ctidh512/ctidh_not_supported.go
+++ b/nike/ctidh/ctidh512/ctidh_not_supported.go
@@ -1,0 +1,11 @@
+//go:build windows
+// +build windows
+
+// SPDX-FileCopyrightText: (c) 2024 David Stainton
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package ctidh511
+
+import "github.com/katzenpost/hpqc/nike"
+
+func Scheme() nike.Scheme { return nil }

--- a/nike/ctidh/ctidh512/ctidh_not_supported.go
+++ b/nike/ctidh/ctidh512/ctidh_not_supported.go
@@ -1,4 +1,4 @@
-//go:build darwin && amd64
+//go:build darwin || windows
 
 // SPDX-FileCopyrightText: (c) 2024 David Stainton
 // SPDX-License-Identifier: AGPL-3.0-only

--- a/nike/ctidh/ctidh512/ctidh_not_supported.go
+++ b/nike/ctidh/ctidh512/ctidh_not_supported.go
@@ -1,10 +1,9 @@
-//go:build windows
-// +build windows
+//go:build darwin && amd64
 
 // SPDX-FileCopyrightText: (c) 2024 David Stainton
 // SPDX-License-Identifier: AGPL-3.0-only
 
-package ctidh511
+package ctidh512
 
 import "github.com/katzenpost/hpqc/nike"
 

--- a/nike/ctidh/ctidh512/ctidh_test.go
+++ b/nike/ctidh/ctidh512/ctidh_test.go
@@ -1,3 +1,5 @@
+//go:build !darwin && !windows
+
 // SPDX-FileCopyrightText: Copyright (C) 2022-2024  David Stainton.
 // SPDX-License-Identifier: AGPL-3.0-only
 

--- a/nike/ctidh/ctidh512/ctidh_test.go
+++ b/nike/ctidh/ctidh512/ctidh_test.go
@@ -1,18 +1,5 @@
-// ctidh_test.go - Adapts ctidh module to our NIKE interface.
-// Copyright (C) 2022  David Stainton.
-//
-// This program is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Affero General Public License as
-// published by the Free Software Foundation, either version 3 of the
-// License, or (at your option) any later version.
-//
-// This program is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU Affero General Public License for more details.
-//
-// You should have received a copy of the GNU Affero General Public License
-// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+// SPDX-FileCopyrightText: Copyright (C) 2022-2024  David Stainton.
+// SPDX-License-Identifier: AGPL-3.0-only
 
 package ctidh512
 

--- a/nike/diffiehellman/dh.go
+++ b/nike/diffiehellman/dh.go
@@ -6,6 +6,7 @@ package diffiehellman
 import (
 	"encoding/base64"
 	"errors"
+	"fmt"
 	"io"
 
 	"gitlab.com/elixxir/crypto/cyclic"
@@ -184,7 +185,7 @@ func (p *PrivateKey) Bytes() []byte {
 
 func (p *PrivateKey) FromBytes(data []byte) error {
 	if len(data) != Scheme().PrivateKeySize() {
-		return errors.New("invalid key size")
+		return fmt.Errorf("invalid key size, expected %d but got %d", Scheme().PrivateKeySize(), len(data))
 	}
 	return p.privateKey.BinaryDecode(data)
 }
@@ -243,7 +244,7 @@ func (p *PublicKey) Bytes() []byte {
 
 func (p *PublicKey) FromBytes(data []byte) error {
 	if len(data) != Scheme().PublicKeySize() {
-		return errors.New("invalid key size")
+		return fmt.Errorf("invalid key size, expected %d but got %d", Scheme().PublicKeySize(), len(data))
 	}
 	err := p.publicKey.BinaryDecode(data)
 	if err != nil {

--- a/nike/hybrid/ctidh.go
+++ b/nike/hybrid/ctidh.go
@@ -1,5 +1,4 @@
-//go:build !windows
-// +build !windows
+//go:build !windows && !darwin
 
 // SPDX-FileCopyrightText: (c) 2024 David Stainton
 // SPDX-License-Identifier: AGPL-3.0-only

--- a/nike/hybrid/ctidh.go
+++ b/nike/hybrid/ctidh.go
@@ -1,3 +1,9 @@
+//go:build !windows
+// +build !windows
+
+// SPDX-FileCopyrightText: (c) 2024 David Stainton
+// SPDX-License-Identifier: AGPL-3.0-only
+
 package hybrid
 
 import (

--- a/nike/hybrid/ctidh_not_supported.go
+++ b/nike/hybrid/ctidh_not_supported.go
@@ -1,0 +1,14 @@
+//go:build windows
+// +build windows
+
+// SPDX-FileCopyrightText: (c) 2024 David Stainton
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package hybrid
+
+import "github.com/katzenpost/hpqc/nike"
+
+var CTIDH511X25519 nike.Scheme = nil
+var CTIDH512X25519 nike.Scheme = nil
+var CTIDH1024X25519 nike.Scheme = nil
+var CTIDH2048X25519 nike.Scheme = nil

--- a/nike/hybrid/ctidh_not_supported.go
+++ b/nike/hybrid/ctidh_not_supported.go
@@ -1,5 +1,4 @@
-//go:build windows
-// +build windows
+//go:build windows || darwin
 
 // SPDX-FileCopyrightText: (c) 2024 David Stainton
 // SPDX-License-Identifier: AGPL-3.0-only

--- a/nike/schemes/schemes.go
+++ b/nike/schemes/schemes.go
@@ -15,12 +15,7 @@ import (
 	"github.com/katzenpost/hpqc/rand"
 )
 
-var allSchemes = [...]nike.Scheme{
-
-	// classical NIKE schemes
-	x25519.Scheme(rand.Reader),
-	x448.Scheme(rand.Reader),
-	diffiehellman.Scheme(),
+var potentialSchemes = [...]nike.Scheme{
 
 	// post quantum NIKE schemes
 	ctidh511.Scheme(),
@@ -29,19 +24,32 @@ var allSchemes = [...]nike.Scheme{
 	ctidh2048.Scheme(),
 
 	// hybrid NIKE schemes
-
 	hybrid.CTIDH511X25519,
 	hybrid.CTIDH512X25519,
 	hybrid.CTIDH1024X25519,
 	hybrid.CTIDH2048X25519,
+}
 
-	hybrid.NOBS_CSIDH512X25519, // XXX TODO: deprecate and remove.
+var allSchemes = []nike.Scheme{
+
+	// classical NIKE schemes
+	x25519.Scheme(rand.Reader),
+	x448.Scheme(rand.Reader),
+	diffiehellman.Scheme(),
+
+	// XXX TODO: deprecate and remove.
+	hybrid.NOBS_CSIDH512X25519,
 }
 
 var allSchemeNames map[string]nike.Scheme
 
 func init() {
 	allSchemeNames = make(map[string]nike.Scheme)
+	for _, scheme := range potentialSchemes {
+		if scheme != nil {
+			allSchemes = append(allSchemes, scheme)
+		}
+	}
 	for _, scheme := range allSchemes {
 		allSchemeNames[strings.ToLower(scheme.Name())] = scheme
 	}

--- a/sign/hybrid/sphincsplus.go
+++ b/sign/hybrid/sphincsplus.go
@@ -1,0 +1,17 @@
+//go:build !windows
+// +build !windows
+
+// SPDX-FileCopyrightText: (c) 2024 David Stainton
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package hybrid
+
+import (
+	"github.com/katzenpost/circl/sign/ed448"
+
+	"github.com/katzenpost/hpqc/sign/ed25519"
+	"github.com/katzenpost/hpqc/sign/sphincsplus"
+)
+
+var Ed25519Sphincs = New("Ed25519 Sphincs+", ed25519.Scheme(), sphincsplus.Scheme())
+var Ed448Sphincs = New("Ed448-Sphincs+", ed448.Scheme(), sphincsplus.Scheme())

--- a/sign/hybrid/sphincsplus_not_supported.go
+++ b/sign/hybrid/sphincsplus_not_supported.go
@@ -1,0 +1,11 @@
+//go:build windows
+
+// SPDX-FileCopyrightText: (c) 2024 David Stainton
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package hybrid
+
+import "github.com/katzenpost/hpqc/sign"
+
+var Ed25519Sphincs sign.Scheme = nil
+var Ed448Sphincs sign.Scheme = nil

--- a/sign/schemes/schemes.go
+++ b/sign/schemes/schemes.go
@@ -20,9 +20,9 @@ var potentialSchemes = [...]sign.Scheme{
 	// post quantum
 	sphincsplus.Scheme(),
 
-	// hybrid post quantum
-	hybrid.New("Ed25519 Sphincs+", ed25519.Scheme(), sphincsplus.Scheme()),
-	hybrid.New("Ed448-Sphincs+", ed448.Scheme(), sphincsplus.Scheme()),
+	// post quantum hybrids
+	hybrid.Ed25519Sphincs,
+	hybrid.Ed448Sphincs,
 }
 
 var allSchemes = []sign.Scheme{

--- a/sign/sphincsplus/sphincs.go
+++ b/sign/sphincsplus/sphincs.go
@@ -1,4 +1,4 @@
-//go:build (darwin || linux) && amd64 && !windows
+//go:build !windows
 
 // SPDX-FileCopyrightText: (c) 2022-2024 David Stainton
 // SPDX-License-Identifier: AGPL-3.0-only

--- a/sign/sphincsplus/sphincs.go
+++ b/sign/sphincsplus/sphincs.go
@@ -1,4 +1,4 @@
-//go:build (darwin || linux) && amd64
+//go:build (darwin || linux) && amd64 && !windows
 
 // SPDX-FileCopyrightText: (c) 2022-2024 David Stainton
 // SPDX-License-Identifier: AGPL-3.0-only

--- a/sign/sphincsplus/sphincs_not_supported.go
+++ b/sign/sphincsplus/sphincs_not_supported.go
@@ -1,4 +1,4 @@
-//go:build !darwin || !linux
+//go:build !linux && !darwin
 
 package sphincsplus
 

--- a/sign/sphincsplus/sphincs_not_supported.go
+++ b/sign/sphincsplus/sphincs_not_supported.go
@@ -1,6 +1,6 @@
 //go:build (!darwin || !linux) && !amd64
 
-package p
+package sphincsplus
 
 import "github.com/katzenpost/hpqc/sign"
 

--- a/sign/sphincsplus/sphincs_not_supported.go
+++ b/sign/sphincsplus/sphincs_not_supported.go
@@ -1,4 +1,4 @@
-//go:build (darwin && !amd64) || (linux && !amd64) || (!linux && !darwin) || windows
+//go:build windows
 
 package sphincsplus
 

--- a/sign/sphincsplus/sphincs_not_supported.go
+++ b/sign/sphincsplus/sphincs_not_supported.go
@@ -1,4 +1,4 @@
-//go:build (darwin && !amd64) || (linux && !amd64) || (!linux && !darwin)
+//go:build (darwin && !amd64) || (linux && !amd64) || (!linux && !darwin) || windows
 
 package sphincsplus
 

--- a/sign/sphincsplus/sphincs_not_supported.go
+++ b/sign/sphincsplus/sphincs_not_supported.go
@@ -1,4 +1,4 @@
-//go:build (!darwin || !linux) && !amd64
+//go:build !darwin || !linux
 
 package sphincsplus
 

--- a/sign/sphincsplus/sphincs_test.go
+++ b/sign/sphincsplus/sphincs_test.go
@@ -1,4 +1,4 @@
-//go:build (darwin || linux) && amd64
+//go:build !windows
 
 // SPDX-FileCopyrightText: (c) 2022-2024 David Stainton
 // SPDX-License-Identifier: AGPL-3.0-only

--- a/sign/sphincsplus/sphincs_test.go
+++ b/sign/sphincsplus/sphincs_test.go
@@ -1,6 +1,4 @@
 //go:build (darwin || linux) && amd64
-// +build darwin linux
-// +build amd64
 
 // SPDX-FileCopyrightText: (c) 2022-2024 David Stainton
 // SPDX-License-Identifier: AGPL-3.0-only


### PR DESCRIPTION

This library hpqc has only two primitives that use cgo:

1. CTIDH (4 key sizes)
2. Sphinsplus

In this pull request I make appropriate use of build tags to make sure that this library compiles and is usable on all platforms. We do this by making candidate lists of schemes and then later filtering out the nil schemes. There are various constructors that will produce a nil scheme on certain platforms due to the build tags so that it avoids importing the cgo which would have broken the build.
