### PR TITLE
README, CHANGELOG: hpqc 0.0.1 is on PyPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,10 +152,20 @@ per-file symlinks under `py/tests/.../vectors/`, so any divergence
 between the two ports surfaces immediately as a failing assertion
 on whichever side runs first.
 
+### Installing it
+
+```bash
+pip install hpqc
+```
+
+The CTIDH wrappers pull in the upstream `highctidh` package (also
+a runtime dependency); see
+[CTIDH](#the-pq-nike-ctidh-via-highctidh) below for build notes.
+
 ### Running the unit tests
 
-The package is not yet published to PyPI. Install from this
-checkout into a virtualenv and run pytest:
+The test suite is not shipped with the PyPI wheel; clone the repo
+and install from the source checkout to run it:
 
 ```bash
 cd hpqc/py
@@ -164,23 +174,6 @@ source .venv/bin/activate
 pip install -e ".[test]"
 pytest
 ```
-
-The CTIDH tests pull in the upstream `highctidh` package (also a
-runtime dependency of `hpqc.nike.ctidh*`); see
-[CTIDH](#the-pq-nike-ctidh-via-highctidh) below for build notes.
-
-### Using it from another project
-
-Until PyPI publication, depend on the source checkout directly. The
-simplest way is an editable install from your project's virtualenv:
-
-```bash
-pip install -e /path/to/hpqc/py
-```
-
-or the equivalent entry in your project's manifest. PyPI
-publication is coming soon, at which point the usual
-`pip install hpqc` will work.
 
 
 ## Using existing NIKE Schemes

--- a/py/CHANGELOG.md
+++ b/py/CHANGELOG.md
@@ -16,7 +16,7 @@ side, are also recorded in the repository-root
 Nothing here yet.
 
 
-## [0.0.1] - Unreleased
+## [0.0.1] - 2026-05-04
 
 Initial public release.
 

--- a/py/README.md
+++ b/py/README.md
@@ -44,21 +44,19 @@ whichever side runs first.
 
 ## Installation
 
-The package is not yet published to PyPI. Until it is, install from
-a checkout:
-
-```bash
-pip install -e /path/to/hpqc/py
-```
-
-Once published:
-
 ```bash
 pip install hpqc
 ```
 
 Runtime dependencies (`pynacl`, `cryptography`, `cbor2`,
 `highctidh`) are pulled in automatically.
+
+To install from a source checkout instead (for example to test an
+unreleased change):
+
+```bash
+pip install -e /path/to/hpqc/py
+```
 
 
 ## Quick start


### PR DESCRIPTION
The package is now published at
https://pypi.org/project/hpqc/0.0.1/, so "pip install hpqc" works without further ceremony. Updates the install prose in both READMEs to that effect, demotes the editable-install instructions to the "working from a source checkout" case, and removes the "PyPI publication is coming soon" line. Records 2026-05-04 as the release date in py/CHANGELOG.md.