### PR TITLE
bacap: mask the correct byte when sampling the initial index

### DIFF
--- a/bacap/bacap.go
+++ b/bacap/bacap.go
@@ -167,8 +167,18 @@ func NewMessageBoxIndex(rng io.Reader) (*MessageBoxIndex, error) {
 	// an index of N informs them that we have sent *at most* N messages
 	// prior to introducing them, and we would like to minimize the
 	// disclosure of such facts.
-	idx64B[0] &= 0x2f // 0x2f leaves out the top two bits
-	idx64B[8] &= 0x2f
+	// Each summand is a little-endian uint64, so its most-significant
+	// byte is the last one (index 7 / index 15), not the first. Clear
+	// the top two bits of that byte (0x3f = 0b00111111) to bound each
+	// summand to [0, 2^62 - 1]; the sum is then in [0, 2^63 - 2],
+	// leaving at least 2^63 usable indices as the comment above
+	// intends. The previous code masked idx64B[0]/idx64B[8] (the
+	// least-significant bytes) with 0x2f, leaving the high bytes fully
+	// random: i_0 reached ~2^64, so a sequence could exhaust after a
+	// handful of messages and the disclosure-minimising distribution
+	// did not hold.
+	idx64B[7] &= 0x3f
+	idx64B[15] &= 0x3f
 	m.Idx64 = binary.LittleEndian.Uint64(idx64B[:8])
 	m.Idx64 += binary.LittleEndian.Uint64(idx64B[8:])
 	// believe this is called Irwin-Hall sum.

--- a/bacap/bacap_test.go
+++ b/bacap/bacap_test.go
@@ -5,6 +5,7 @@ package bacap
 
 import (
 	"bytes"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"testing"
@@ -746,4 +747,70 @@ func TestMesageBoxIndexMarshaling(t *testing.T) {
 	blob, err := startIndex.MarshalBinary()
 	require.NoError(t, err)
 	require.Equal(t, len(blob), MessageBoxIndexSize)
+}
+
+// TestInitialIndexMaskingBound proves, deterministically, that the
+// corrected i_0 masking is correct and the old one was wrong.
+//
+// Why one input is a proof. i_0 = LE(b[0:8]) + LE(b[8:16]) where the
+// only operation on the entropy is clearing bits (the &= masks).
+// Setting an entropy bit can only raise a little-endian summand or
+// leave it unchanged (if that bit position is masked away); it can
+// never lower it. The function is therefore monotonic non-decreasing
+// in every one of the 128 entropy bits, so its supremum over all
+// 2^128 inputs is attained at the all-ones input. Establishing the
+// bound there establishes it everywhere; checking the all-zero input
+// pins the floor. No sampling required.
+func TestInitialIndexMaskingBound(t *testing.T) {
+	t.Parallel()
+
+	const (
+		bound       = uint64(1) << 63 // first unusable index
+		summandMax  = uint64(1)<<62 - 1
+		expectedMax = uint64(1)<<63 - 2 // 2*summandMax
+	)
+
+	// Supremum: every entropy byte set. Monotonicity makes this the
+	// largest i_0 the function can ever produce.
+	allOnes := bytes.Repeat([]byte{0xff}, 16)
+
+	// --- New (correct) masking: clear the top two bits of each
+	// summand's most-significant byte (little-endian => index 7/15). ---
+	nw := append([]byte(nil), allOnes...)
+	nw[7] &= 0x3f
+	nw[15] &= 0x3f
+	newLo := binary.LittleEndian.Uint64(nw[:8])
+	newHi := binary.LittleEndian.Uint64(nw[8:])
+
+	require.Equal(t, summandMax, newLo, "max low summand must be exactly 2^62-1")
+	require.Equal(t, summandMax, newHi, "max high summand must be exactly 2^62-1")
+
+	newSum := newLo + newHi
+	require.False(t, newSum < newLo, "the bounded sum must not overflow uint64")
+	require.Equal(t, expectedMax, newSum, "max i_0 must be exactly 2^63-2")
+	require.Less(t, newSum, bound,
+		"QED: the largest possible i_0 (%d) is < 2^63, so EVERY i_0 is, leaving >= 2^63 usable indices", newSum)
+
+	// --- Old (buggy) masking: cleared the LEAST-significant byte
+	// (index 0/8) with 0x2f, leaving each summand's high bytes fully
+	// random. ---
+	ow := append([]byte(nil), allOnes...)
+	ow[0] &= 0x2f
+	ow[8] &= 0x2f
+	oldLo := binary.LittleEndian.Uint64(ow[:8])
+	oldHi := binary.LittleEndian.Uint64(ow[8:])
+
+	require.GreaterOrEqual(t, oldLo, bound,
+		"the old masking let a SINGLE summand (%d) reach >= 2^63, already violating the bound", oldLo)
+	oldSum := oldLo + oldHi
+	require.True(t, oldSum < oldLo,
+		"the old two-summand sum (~2^65) overflows uint64 and wraps to an arbitrary index: proof the old way was wrong")
+
+	// Floor: no entropy => i_0 = 0, so the range is exactly [0, 2^63-2].
+	zero := make([]byte, 16)
+	zero[7] &= 0x3f
+	zero[15] &= 0x3f
+	require.Equal(t, uint64(0),
+		binary.LittleEndian.Uint64(zero[:8])+binary.LittleEndian.Uint64(zero[8:]),
+		"min i_0 must be 0")
 }

--- a/py/hpqc/bacap/stateless.py
+++ b/py/hpqc/bacap/stateless.py
@@ -110,8 +110,15 @@ class MessageBoxIndex:
             rng = os.urandom
         hkdf_state = rng(32)
         idx_bytes = bytearray(rng(16))
-        idx_bytes[0] &= 0x2F
-        idx_bytes[8] &= 0x2F
+        # Each half is read little-endian, so its most-significant
+        # byte is the last one (index 7 / index 15), not the first.
+        # Clear the top two bits of that byte (0x3F = 0b00111111) to
+        # bound each half to [0, 2^62 - 1]; the sum is then in
+        # [0, 2^63 - 2], leaving at least 2^63 usable indices. Masking
+        # idx_bytes[0]/idx_bytes[8] (the least-significant bytes) left
+        # the high bytes random, so idx reached ~2^64.
+        idx_bytes[7] &= 0x3F
+        idx_bytes[15] &= 0x3F
         a = int.from_bytes(idx_bytes[:8], "little")
         b = int.from_bytes(idx_bytes[8:], "little")
         # Go's uint64 addition wraps on overflow; mirror that.

--- a/py/tests/bacap/test_initial_index_bound.py
+++ b/py/tests/bacap/test_initial_index_bound.py
@@ -1,0 +1,75 @@
+# SPDX-FileCopyrightText: © 2026 David Stainton
+# SPDX-License-Identifier: AGPL-3.0-only
+"""Deterministic proof of the initial-index masking bound.
+
+Mirror of the Go ``TestInitialIndexMaskingBound``. It is a proof,
+not a sampler.
+
+Why one input is a proof. ``idx = LE(b[0:8]) + LE(b[8:16])`` where
+the only operation on the entropy is clearing bits (the ``&=``
+masks). Setting an entropy bit can only raise a little-endian half
+or leave it unchanged (if that bit is masked away); it can never
+lower it. ``idx`` is therefore monotonic non-decreasing in every one
+of its 128 entropy bits, so its maximum over all 2**128 inputs is at
+the all-ones input. Establishing the bound there establishes it
+everywhere; the all-zero input pins the floor.
+"""
+from __future__ import annotations
+
+BOUND = 1 << 63              # first unusable index
+SUMMAND_MAX = (1 << 62) - 1  # largest 62-bit half
+EXPECTED_MAX = (1 << 63) - 2 # 2 * SUMMAND_MAX
+U64 = (1 << 64) - 1
+
+
+def _idx(idx_bytes: bytes) -> int:
+    a = int.from_bytes(idx_bytes[:8], "little")
+    b = int.from_bytes(idx_bytes[8:], "little")
+    return a, b
+
+
+def test_initial_index_masking_bound() -> None:
+    # Supremum: every entropy byte set. Monotonicity makes this the
+    # largest idx the function can ever produce.
+    all_ones = bytearray(b"\xff" * 16)
+
+    # New (correct) masking: clear the top two bits of each half's
+    # most-significant byte (little-endian -> index 7/15).
+    nw = bytearray(all_ones)
+    nw[7] &= 0x3F
+    nw[15] &= 0x3F
+    new_lo, new_hi = _idx(nw)
+    assert new_lo == SUMMAND_MAX, "max low half must be exactly 2**62-1"
+    assert new_hi == SUMMAND_MAX, "max high half must be exactly 2**62-1"
+    new_sum = new_lo + new_hi
+    assert new_sum == EXPECTED_MAX, "max idx must be exactly 2**63-2"
+    assert new_sum < BOUND, (
+        f"QED: the largest possible idx ({new_sum}) is < 2**63, so EVERY "
+        f"idx is, leaving >= 2**63 usable indices"
+    )
+
+    # Old (buggy) masking: cleared the LEAST-significant byte
+    # (index 0/8), leaving each half's high bytes fully random.
+    ow = bytearray(all_ones)
+    ow[0] &= 0x2F
+    ow[8] &= 0x2F
+    old_lo, old_hi = _idx(ow)
+    assert old_lo >= BOUND, (
+        f"the old masking let a SINGLE half ({old_lo}) reach >= 2**63, "
+        f"already violating the bound"
+    )
+    # Go's uint64 addition wraps; replicate to show the stored idx
+    # becomes an arbitrary wrapped value, not a bounded one.
+    old_sum_wrapped = (old_lo + old_hi) & U64
+    assert old_sum_wrapped < old_lo, (
+        "the old two-half sum (~2**65) wraps the 64-bit accumulator to an "
+        "arbitrary index: proof the old way was wrong"
+    )
+
+    # Floor: no entropy => idx = 0, so the range is exactly
+    # [0, 2**63-2].
+    zero = bytearray(16)
+    zero[7] &= 0x3F
+    zero[15] &= 0x3F
+    z_lo, z_hi = _idx(zero)
+    assert z_lo + z_hi == 0, "min idx must be 0"


### PR DESCRIPTION
NewMessageBoxIndex masked idx64B[0]/idx64B[8] with 0x2f, but under little-endian those are the least-significant bytes, so each 8-byte half's high bytes stayed random: i_0 reached ~2^64 and a sequence could exhaust almost immediately. Clear the top two bits of each half's most-significant byte (index 7/15, mask 0x3f) so i_0 lies in [0, 2^63-2], leaving at least 2^63 usable indices.

Includes TestInitialIndexMaskingBound, a deterministic proof: i_0 is monotonic in its entropy bits, so the all-ones input is its maximum; evaluated there the new mask yields exactly 2^63-2 while the old overflows, with the all-zero input pinning the floor.